### PR TITLE
fix: correct in-transit quantity for SHIPPED inbound shipments

### DIFF
--- a/client/packages/invoices/src/InboundShipment/DetailView/Tabs/DeliveryStatus.tsx
+++ b/client/packages/invoices/src/InboundShipment/DetailView/Tabs/DeliveryStatus.tsx
@@ -32,8 +32,7 @@ export const DeliveryTab = ({
 
   const inTransit = (row: InboundLineFragment) => {
     const inTransit = row.purchaseOrderLine?.inTransitNumberOfUnits ?? 0;
-    return data?.status === InvoiceNodeStatus.Delivered ||
-      data?.status === InvoiceNodeStatus.Shipped
+    return data?.status === InvoiceNodeStatus.Delivered
       ? inTransit - row.numberOfPacks * row.packSize
       : inTransit;
   };


### PR DESCRIPTION
Fix incorrect in-transit quantity calculation on the Delivery Status tab of inbound shipments.

When status is SHIPPED, the frontend was subtracting the current row's quantity from `inTransitNumberOfUnits`, showing "PO qty - this delivery" instead of the correct total. The SQL view already correctly includes SHIPPED quantities, so no subtraction is needed.

Closes #1

Generated with [Claude Code](https://claude.ai/code)