### PR TITLE
feat: add keyboard navigation to table rows

### DIFF
--- a/client/packages/common/src/ui/layout/tables/useTableDisplayOptions.tsx
+++ b/client/packages/common/src/ui/layout/tables/useTableDisplayOptions.tsx
@@ -261,6 +261,29 @@ export const useTableDisplayOptions = <T extends MRT_RowData>({
           );
           if (onRowClick) onRowClick(row.original, isCtrlClick);
         },
+        ...(onRowClick
+          ? {
+              tabIndex: 0,
+              onKeyDown: (e: React.KeyboardEvent<HTMLTableRowElement>) => {
+                // Only handle keyboard navigation when focus is directly on the
+                // row itself, not on an interactive child element (e.g. inputs)
+                if (e.target !== e.currentTarget) return;
+                if (e.key === 'ArrowDown') {
+                  e.preventDefault();
+                  (
+                    e.currentTarget.nextElementSibling as HTMLElement
+                  )?.focus();
+                } else if (e.key === 'ArrowUp') {
+                  e.preventDefault();
+                  (
+                    e.currentTarget.previousElementSibling as HTMLElement
+                  )?.focus();
+                } else if (e.key === 'Enter') {
+                  onRowClick(row.original, false);
+                }
+              },
+            }
+          : {}),
         sx: {
           backgroundColor: 'inherit',
           minHeight: table.getState().density === 'compact' ? '32px' : '40px',
@@ -275,6 +298,11 @@ export const useTableDisplayOptions = <T extends MRT_RowData>({
           },
           fontStyle: row.getCanExpand() ? 'italic' : 'normal',
           cursor: onRowClick ? 'pointer' : 'default',
+          // Show a visible focus ring when navigating rows with keyboard
+          '&:focus-visible': {
+            outline: theme => `2px solid ${theme.palette.primary.main}`,
+            outlineOffset: '-2px',
+          },
         },
       };
       return {


### PR DESCRIPTION
Adds keyboard navigation to tables with clickable rows:

- `ArrowDown` / `ArrowUp` to move focus between rows
- `Enter` to trigger the row click action
- Visible focus ring for accessibility
- Navigation is skipped when focus is inside an input or interactive child

Closes #3

Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Table rows now support keyboard navigation with Arrow Up/Down keys to move between rows
  * Enter key activates row actions when navigating via keyboard
  * Added visible focus indicators for improved keyboard navigation experience

<!-- end of auto-generated comment: release notes by coderabbit.ai -->