### PR TITLE
feat: add keyboard navigation to table rows

### DIFF
--- a/client/packages/common/src/ui/layout/tables/useBaseMaterialTable.tsx
+++ b/client/packages/common/src/ui/layout/tables/useBaseMaterialTable.tsx
@@ -166,6 +166,7 @@ export const useBaseMaterialTable = <T extends MRT_RowData>({
     isMobile,
     onSaveAsGlobalDefault,
     globalDefaults: resetDefaults,
+    data,
   });
 
   const table = useMaterialReactTable<T>({

--- a/client/packages/common/src/ui/layout/tables/useTableDisplayOptions.tsx
+++ b/client/packages/common/src/ui/layout/tables/useTableDisplayOptions.tsx
@@ -261,6 +261,29 @@ export const useTableDisplayOptions = <T extends MRT_RowData>({
           );
           if (onRowClick) onRowClick(row.original, isCtrlClick);
         },
+        ...(onRowClick
+          ? {
+              tabIndex: 0,
+              onKeyDown: (e: React.KeyboardEvent<HTMLTableRowElement>) => {
+                // Only handle keyboard navigation when focus is directly on the
+                // row itself, not on an interactive child element (e.g. inputs)
+                if (e.target !== e.currentTarget) return;
+                if (e.key === 'ArrowDown') {
+                  e.preventDefault();
+                  (
+                    e.currentTarget.nextElementSibling as HTMLElement
+                  )?.focus();
+                } else if (e.key === 'ArrowUp') {
+                  e.preventDefault();
+                  (
+                    e.currentTarget.previousElementSibling as HTMLElement
+                  )?.focus();
+                } else if (e.key === 'Enter') {
+                  onRowClick(row.original, false);
+                }
+              },
+            }
+          : {}),
         sx: {
           backgroundColor: 'inherit',
           minHeight: table.getState().density === 'compact' ? '32px' : '40px',
@@ -275,6 +298,11 @@ export const useTableDisplayOptions = <T extends MRT_RowData>({
           },
           fontStyle: row.getCanExpand() ? 'italic' : 'normal',
           cursor: onRowClick ? 'pointer' : 'default',
+          // Show a visible focus ring when navigating rows with keyboard
+          '&:focus-visible': {
+            outline: theme => `2px solid ${theme.palette.primary.main}`,
+            outlineOffset: '-2px',
+          },
         },
       };
       return {

--- a/client/packages/common/src/ui/layout/tables/useTableDisplayOptions.tsx
+++ b/client/packages/common/src/ui/layout/tables/useTableDisplayOptions.tsx
@@ -68,11 +68,18 @@ export const useTableDisplayOptions = <T extends MRT_RowData>({
   // This object is merged with the default row props in muiTableBodyRowProps
   // below. We can do the same for other muiTable props if needed in future.
   muiTableBodyRowProps?: MRT_TableOptions<T>['muiTableBodyRowProps'];
+  data?: T[];
 }): Partial<MRT_TableOptions<T>> => {
   const t = useTranslation();
   // Roving tabindex: track which row currently "owns" tabIndex=0 so Tab
   // enters/exits the table at a single point rather than cycling every row.
   const [focusedRowId, setFocusedRowId] = React.useState<string | null>(null);
+
+  // Reset focused row when data changes (e.g. pagination, filtering) so the
+  // first row regains tabIndex=0 and the table remains keyboard-reachable.
+  React.useEffect(() => {
+    setFocusedRowId(null);
+  }, [data]);
 
   // shared between the table body and head to ensure consistent padding
   const padding = (

--- a/client/packages/common/src/ui/layout/tables/useTableDisplayOptions.tsx
+++ b/client/packages/common/src/ui/layout/tables/useTableDisplayOptions.tsx
@@ -75,11 +75,21 @@ export const useTableDisplayOptions = <T extends MRT_RowData>({
   // enters/exits the table at a single point rather than cycling every row.
   const [focusedRowId, setFocusedRowId] = React.useState<string | null>(null);
 
+  // Use a content-based fingerprint rather than the array reference to avoid
+  // spurious resets when callers pass inline/derived arrays (e.g.
+  // `data={rows.map(fn)}`). Length + first/last item IDs covers the common
+  // cases (pagination, filtering) without false-firing on reference-identity
+  // changes caused by re-renders.
+  const firstItem = data?.[0] as Record<string, unknown> | undefined;
+  const lastItem = data?.[data.length - 1] as Record<string, unknown> | undefined;
+  const dataFingerprint = `${data?.length ?? 0}:${String(firstItem?.id ?? '')}:${String(lastItem?.id ?? '')}`;
+
   // Reset focused row when data changes (e.g. pagination, filtering) so the
   // first row regains tabIndex=0 and the table remains keyboard-reachable.
   React.useEffect(() => {
     setFocusedRowId(null);
-  }, [data]);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [dataFingerprint]);
 
   // shared between the table body and head to ensure consistent padding
   const padding = (
@@ -276,15 +286,15 @@ export const useTableDisplayOptions = <T extends MRT_RowData>({
               // Roving tabindex: only the focused row (or the first row as
               // entry point) has tabIndex=0; all others are -1 so Tab moves
               // in/out of the table in a single keystroke.
-              tabIndex:
-                focusedRowId === null
-                  ? row.index === 0
-                    ? 0
-                    : -1
-                  : focusedRowId === row.id
-                    ? 0
-                    : -1,
-              onFocus: () => setFocusedRowId(row.id),
+              tabIndex: (focusedRowId !== null ? focusedRowId === row.id : row.index === 0) ? 0 : -1,
+              // Hint to screen readers that this row is interactive.
+              // Consumers can pass a more descriptive aria-label via
+              // muiTableBodyRowProps if they know the row content.
+              role: 'button',
+              // Guard against no-op updates: only update state when the focused
+              // row actually changes to avoid unnecessary full-table re-renders.
+              onFocus: () =>
+                setFocusedRowId(prev => (prev === row.id ? prev : row.id)),
               onKeyDown: (e: React.KeyboardEvent<HTMLTableRowElement>) => {
                 // Only handle keyboard navigation when focus is directly on the
                 // row itself, not on an interactive child element (e.g. inputs)
@@ -293,6 +303,9 @@ export const useTableDisplayOptions = <T extends MRT_RowData>({
                   e.preventDefault();
                   // Walk forward to find the next focusable TR sibling,
                   // skipping any non-TR elements (e.g. sub-row detail panels).
+                  // NOTE: this traversal only sees DOM-visible rows; with MRT
+                  // row virtualisation enabled the sibling walk will stop at the
+                  // edge of the rendered window and won't reach unrendered rows.
                   let next = e.currentTarget.nextElementSibling;
                   while (
                     next &&
@@ -312,6 +325,8 @@ export const useTableDisplayOptions = <T extends MRT_RowData>({
                   }
                   if (prev instanceof HTMLElement) prev.focus();
                 } else if (e.key === 'Enter' || e.key === ' ') {
+                  // Space is intentional: follows ARIA button/grid conventions
+                  // where Space activates the focused item.
                   e.preventDefault();
                   onRowClick(row.original, false);
                 }

--- a/client/packages/common/src/ui/layout/tables/useTableDisplayOptions.tsx
+++ b/client/packages/common/src/ui/layout/tables/useTableDisplayOptions.tsx
@@ -70,6 +70,9 @@ export const useTableDisplayOptions = <T extends MRT_RowData>({
   muiTableBodyRowProps?: MRT_TableOptions<T>['muiTableBodyRowProps'];
 }): Partial<MRT_TableOptions<T>> => {
   const t = useTranslation();
+  // Roving tabindex: track which row currently "owns" tabIndex=0 so Tab
+  // enters/exits the table at a single point rather than cycling every row.
+  const [focusedRowId, setFocusedRowId] = React.useState<string | null>(null);
 
   // shared between the table body and head to ensure consistent padding
   const padding = (
@@ -263,22 +266,46 @@ export const useTableDisplayOptions = <T extends MRT_RowData>({
         },
         ...(onRowClick
           ? {
-              tabIndex: 0,
+              // Roving tabindex: only the focused row (or the first row as
+              // entry point) has tabIndex=0; all others are -1 so Tab moves
+              // in/out of the table in a single keystroke.
+              tabIndex:
+                focusedRowId === null
+                  ? row.index === 0
+                    ? 0
+                    : -1
+                  : focusedRowId === row.id
+                    ? 0
+                    : -1,
+              onFocus: () => setFocusedRowId(row.id),
               onKeyDown: (e: React.KeyboardEvent<HTMLTableRowElement>) => {
                 // Only handle keyboard navigation when focus is directly on the
                 // row itself, not on an interactive child element (e.g. inputs)
                 if (e.target !== e.currentTarget) return;
                 if (e.key === 'ArrowDown') {
                   e.preventDefault();
-                  (
-                    e.currentTarget.nextElementSibling as HTMLElement
-                  )?.focus();
+                  // Walk forward to find the next focusable TR sibling,
+                  // skipping any non-TR elements (e.g. sub-row detail panels).
+                  let next = e.currentTarget.nextElementSibling;
+                  while (
+                    next &&
+                    !(next instanceof HTMLElement && next.tagName === 'TR')
+                  ) {
+                    next = next.nextElementSibling;
+                  }
+                  if (next instanceof HTMLElement) next.focus();
                 } else if (e.key === 'ArrowUp') {
                   e.preventDefault();
-                  (
-                    e.currentTarget.previousElementSibling as HTMLElement
-                  )?.focus();
-                } else if (e.key === 'Enter') {
+                  let prev = e.currentTarget.previousElementSibling;
+                  while (
+                    prev &&
+                    !(prev instanceof HTMLElement && prev.tagName === 'TR')
+                  ) {
+                    prev = prev.previousElementSibling;
+                  }
+                  if (prev instanceof HTMLElement) prev.focus();
+                } else if (e.key === 'Enter' || e.key === ' ') {
+                  e.preventDefault();
                   onRowClick(row.original, false);
                 }
               },


### PR DESCRIPTION
When a table has an onRowClick handler, rows are now focusable (tabIndex=0) and respond to keyboard events:
- ArrowDown: move focus to the next row
- ArrowUp: move focus to the previous row
- Enter: trigger the row click action

Navigation only activates when focus is on the row itself, not on an interactive child element (inputs, buttons, etc). A visible focus ring is shown via :focus-visible for accessibility.

Fixes #3


